### PR TITLE
Pre-cast the buf into char* for bug to satisfy the static analysis

### DIFF
--- a/common.c
+++ b/common.c
@@ -9,7 +9,7 @@ int read_len(int fd, void *buf, size_t length)
 {
   size_t total = 0;
   while (total < length) {
-    ssize_t read_sz = read(fd, buf + total, length - total);
+    ssize_t read_sz = read(fd, (char *)buf + total, length - total);
     if (read_sz == -1) {
         if (errno == EINTR) {
             // if we get interrupted then we should try reading again
@@ -38,7 +38,7 @@ int write_len(const int fd, const void *buf, size_t length)
 {
   size_t total = 0;
   while (total < length) {
-    ssize_t write_sz = write(fd, buf + total, length - total);
+    ssize_t write_sz = write(fd, (char *)buf + total, length - total);
     if (write_sz == -1) {
         if (errno == EINTR) {
             // if we get interrupted then we should try reading again


### PR DESCRIPTION
I was trying to copy the common.c and common.h files into the phase 1 and 2 repo and these locations fail the static analysis test. Here I cast the buf into char* before "+ total" to satisfy the static analysis test.