### PR TITLE
Fix Hared-coded Difficulty

### DIFF
--- a/server.c
+++ b/server.c
@@ -25,7 +25,7 @@
 FILE *log_file;
 
 static char current_block[MAX_BLOCK_LEN];
-static uint32_t current_difficulty = 0x0000FFF;
+static uint32_t current_difficulty = 0x0000FFFF;
 
 
 


### PR DESCRIPTION
uint32_t current_difficulty should have 8 numbers. I added one number. Maybe it is a typo.