### PR TITLE
Bug: Should close sockets when they're no longer needed.

### DIFF
--- a/server.c
+++ b/server.c
@@ -175,6 +175,7 @@ void *client_thread(void* client_fd) {
                 LOG("ERROR: unknown message type: %d\n", msg.header.msg_type);
         }
     }
+    close(fd);
     return NULL;
 }
 


### PR DESCRIPTION
 I think code should close client sockets after their associated threads finish execution.
I'm not sure if this bug is correct:
In the client_thread function, add close(fd) behind the main loop.